### PR TITLE
[fix] issue with blur in safari

### DIFF
--- a/src/components/CommentsPage/CommentPageTypes/PopupStyles.tsx
+++ b/src/components/CommentsPage/CommentPageTypes/PopupStyles.tsx
@@ -22,7 +22,6 @@ export const useStyles = makeStyles((theme: Theme) => ({
     width: '100%',
     padding: `${theme.spacing(1)}px ${theme.spacing(2)}px`,
     paddingBottom: theme.spacing(4),
-    background: 'linear-gradient(to bottom, white 55%, rgba(0,0,0,0))',
     zIndex: 10,
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
Linear gradient causes blur in safari browser which is not the case for other browsers.
So I have deleted that line of code as there was no change in the view even after removing it.
Do suggest if other workaround is possible.